### PR TITLE
Adding support for multiple opentsdb backend hosts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ publishes stats to OpenTSDB (http://opentsdb.net)
 ## Configuration
 You have to give basic information about your OpenTSDB server to use
 ```
-{ opentsdbHosts: [{host: 'localhost', port: 4242}]
+{
+  opentsdbHosts: [{host: 'localhost', port: 4242}],
+  opentsdbDeadHostRetry: 15,
 , opentsdbTagPrefix: '_t_'
 , opentsdbTagValuePrefix: '_tv_'
 , opentsdbDeadHostRetry: 15

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ publishes stats to OpenTSDB (http://opentsdb.net)
 ## Configuration
 You have to give basic information about your OpenTSDB server to use
 ```
-{ opentsdbHost: 'localhost'
-, opentsdbPort: 4242
+{ opentsdbHosts: [{host: 'localhost', port: 4242}]
 , opentsdbTagPrefix: '_t_'
+, opentsdbTagValuePrefix: '_tv_'
+, opentsdbDeadHostRetry: 15
 }
 ```
 
@@ -21,7 +22,14 @@ You have to give basic information about your OpenTSDB server to use
 This backend allows you to attach OpenTSDB tags to your metrics. To add a counter
 called `gorets` and tag the data `foo=bar`, you'd write the following to statsd:
 
-    gorets._t_foo.bar:261|c
+    gorets._t_foo._tv_bar:261|c
+
+## Multiple opentsdb backend node support
+This fork extends support for opentsdb by allowing you to configure an array of hash elements defining available hosts.
+opentsdbHosts: [{host: 'localhost', port: 4242}]
+
+Further configuration of this feature allows you to set the dead host retry period. Default value for this is 15
+seconds. The configuration option for this setting is opentsdbDeadHostRetry.
 
 ## Dependencies
 - none

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ publishes stats to OpenTSDB (http://opentsdb.net)
 You have to give basic information about your OpenTSDB server to use
 ```
 {
-  opentsdbHosts: [{host: 'localhost', port: 4242}],
-  opentsdbDeadHostRetry: 15,
+  opentsdbHosts: [{host: 'localhost', port: 4242}]
+, opentsdbDeadHostRetry: 15
 , opentsdbTagPrefix: '_t_'
 , opentsdbTagValuePrefix: '_tv_'
 , opentsdbDeadHostRetry: 15

--- a/statsd-opentsdb-backend/index.js
+++ b/statsd-opentsdb-backend/index.js
@@ -53,8 +53,10 @@ var select_host = function opentsdb_select_host() {
     for (var i in opentsdbHosts) {
       // If no deadTime value has been defined we assume host is alive and return it
       if (typeof opentsdbHosts[i].deadTime === 'undefined') {
+        if (debug) util.log('Selected ' + opentsdbHosts[i] + ' as assumed live host.\n');
         return opentsdbHosts[i];
       } else if (get_timestamp() - opentsdbHosts[i].deadTime >= opentsdbDeadHostRetry) {
+        if (debug) util.log('Retrying ' + opentsdbHosts[i] + ' as current live host.\n');
         delete opentsdbHosts[i].deadTime; // Remove expired deadTime
         return opentsdbHosts[i]; // Return host
       }

--- a/statsd-opentsdb-backend/index.js
+++ b/statsd-opentsdb-backend/index.js
@@ -95,7 +95,7 @@ var post_stats = function opentsdb_post_stats(statString) {
 
   if (opentsdbHost) {
     try {
-      var opentsdb = net.createConnection(opentsdbHost.host, opentsdbHost.port);
+      var opentsdb = net.createConnection(opentsdbHost.port, opentsdbHost.host);
       opentsdb.addListener('error', function(connectionException){
         mark_dead_host(opentsdbHost);
 

--- a/statsd-opentsdb-backend/index.js
+++ b/statsd-opentsdb-backend/index.js
@@ -264,7 +264,7 @@ var backend_status = function opentsdb_status(writeCb) {
 exports.init = function opentsdb_init(startup_time, config, events, logger) {
   debug = config.debug;
   opentsdbHosts = config.opentsdbHosts;
-  opentsdbDeadHostRetry = config.opentsdbDeadHostRetry;
+  opentsdbDeadHostRetry = config.opentsdbDeadHostRetry || 15;
   opentsdbSelectedHost = null;
   statsdLogger = logger;
   opentsdbTagPrefix = config.opentsdbTagPrefix;
@@ -293,7 +293,7 @@ exports.init = function opentsdb_init(startup_time, config, events, logger) {
   counterSuffix = counterSuffix !== undefined ? counterSuffix : "";
 
   if (debug) { statsdLogger.log('opentsdbTagPrefix: ' + opentsdbTagPrefix + ", opentsdbTagValuePrefix: " + opentsdbTagValuePrefix, "DEBUG"); }
-  if (debug) { statsdLogger.log('opentesdbDeadHostRetry: ' + opentsdbDeadHostRetry + ', opentsdbHosts: ' + opentsdbHosts, "DEBUG"); }
+  if (debug) { statsdLogger.log('opentsdbDeadHostRetry: ' + opentsdbDeadHostRetry + ', opentsdbHosts: ' + opentsdbHosts, "DEBUG"); }
   
   if (legacyNamespace === false) {
     if (globalPrefix !== "") {

--- a/statsd-opentsdb-backend/index.js
+++ b/statsd-opentsdb-backend/index.js
@@ -295,7 +295,7 @@ exports.init = function opentsdb_init(startup_time, config, events, logger) {
   counterSuffix = counterSuffix !== undefined ? counterSuffix : "";
 
   if (debug) { statsdLogger.log('opentsdbTagPrefix: ' + opentsdbTagPrefix + ", opentsdbTagValuePrefix: " + opentsdbTagValuePrefix, "DEBUG"); }
-  if (debug) { statsdLogger.log('opentsdbDeadHostRetry: ' + opentsdbDeadHostRetry + ', opentsdbHosts: ' + opentsdbHosts, "DEBUG"); }
+  if (debug) { statsdLogger.log('opentsdbDeadHostRetry: ' + opentsdbDeadHostRetry + ', opentsdbHosts: ' + opentsdbHosts.length, "DEBUG"); }
   
   if (legacyNamespace === false) {
     if (globalPrefix !== "") {

--- a/statsd-opentsdb-backend/index.js
+++ b/statsd-opentsdb-backend/index.js
@@ -56,10 +56,10 @@ var select_host = function opentsdb_select_host() {
     for (var i in opentsdbHosts) {
       // If no deadTime value has been defined we assume host is alive and return it
       if (typeof opentsdbHosts[i].deadTime === 'undefined') {
-        if (debug) util.log('Selected ' + opentsdbHosts[i] + ' as assumed live host.\n');
+        if (debug) { util.log('Selected ' + opentsdbHosts[i] + ' as assumed live host.\n'); }
         opentsdbSelectedHost = opentsdbHosts[i];
       } else if (get_timestamp() - opentsdbHosts[i].deadTime >= opentsdbDeadHostRetry) {
-        if (debug) util.log('Retrying ' + opentsdbHosts[i] + ' as current live host.\n');
+        if (debug) { util.log('Retrying ' + opentsdbHosts[i] + ' as current live host.\n'); }
         delete opentsdbHosts[i].deadTime; // Remove expired deadTime
         opentsdbSelectedHost = opentsdbHosts[i];
       }
@@ -293,6 +293,7 @@ exports.init = function opentsdb_init(startup_time, config, events, logger) {
   counterSuffix = counterSuffix !== undefined ? counterSuffix : "";
 
   if (debug) { statsdLogger.log('opentsdbTagPrefix: ' + opentsdbTagPrefix + ", opentsdbTagValuePrefix: " + opentsdbTagValuePrefix, "DEBUG"); }
+  if (debug) { statsdLogger.log('opentesdbDeadHostRetry: ' + opentsdbDeadHostRetry + ', opentsdbHosts: ' + opentsdbHosts, "DEBUG"); }
   
   if (legacyNamespace === false) {
     if (globalPrefix !== "") {


### PR DESCRIPTION
The bulk of this work is geared toward adding support for multiple opentsdb backend hosts. I also added a timestamp utility function as well as updates to the Readme.md.

The selection process is pretty simple, select the first viable host and use it until it becomes unviable. At that time the next viable host will be selected. There is a configurable opentsdbDeadHostRetry which is set to retry a host after 15 seconds. This could be made to be more intelligent but for the purpose in which I decided to create this selection functionality this serves the purpose fine. I also may make this more backwards compatible and build a single element array from the original opentsdbHost opentsdbPort settings that have been removed, thoughts on this?

Thought this may be useful to a greater audience.
